### PR TITLE
Simplify version detection

### DIFF
--- a/Jamroot.jam
+++ b/Jamroot.jam
@@ -1,7 +1,7 @@
 import path ;
 import os ;
 
-CLASP_VERSION = "0.3" ;
+CLASP_VERSION = [ os.environ CLASP_VERSION ] ;
 
 using clang : : [ os.environ CLASP_CLANG_PATH ] ; #   $(APPRES-EXTERNALS-RELEASE)/bin/clang++  ; # CLASP_TOOLSET
 

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ include local.config
 
 export CLASP_HOME = $(shell pwd)
 
-export GIT_COMMIT := $(shell cat 'minor-version-id.txt')
+export GIT_COMMIT := $(shell git describe --match='' --always)
 
 export CLASP_INTERNAL_BUILD_TARGET_DIR = $(shell pwd)/build/clasp
 export EXTERNALS_BUILD_TARGET_DIR = $(EXTERNALS_SOURCE_DIR)/build
@@ -249,9 +249,3 @@ mps-submodule:
 
 asdf-submodule:
 	git submodule add --name updatedAsdf https://github.com/drmeister/asdf.git ./src/lisp/kernel/asdf
-
-
-git-push-master:
-	git rev-parse HEAD > minor-version-id.txt
-	git commit -am "updated minor-version-id.txt"
-	git push origin master

--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@ include local.config
 export CLASP_HOME = $(shell pwd)
 
 export GIT_COMMIT := $(shell git describe --match='' --always)
+export CLASP_VERSION := $(shell git describe --always --abbrev=0)
 
 export CLASP_INTERNAL_BUILD_TARGET_DIR = $(shell pwd)/build/clasp
 export EXTERNALS_BUILD_TARGET_DIR = $(EXTERNALS_SOURCE_DIR)/build

--- a/makefile
+++ b/makefile
@@ -2,8 +2,8 @@ include local.config
 
 export CLASP_HOME = $(shell pwd)
 
-export GIT_COMMIT := $(shell git describe --match='' --always)
-export CLASP_VERSION := $(shell git describe --always --abbrev=0)
+export GIT_COMMIT := $(shell git describe --match='' --always || echo "unknown-commit")
+export CLASP_VERSION := $(shell git describe --always --abbrev=0 || echo "unknown-version")
 
 export CLASP_INTERNAL_BUILD_TARGET_DIR = $(shell pwd)/build/clasp
 export EXTERNALS_BUILD_TARGET_DIR = $(EXTERNALS_SOURCE_DIR)/build


### PR DESCRIPTION
Instead of creating a `minor-version-id.txt` -- which wasn't tracked, anyway -- use `git describe` for both `CLASP_VERSION` and `CLASP_GIT_COMMIT`.

