### PR TITLE
clang-format configuration

### DIFF
--- a/clang-format.sh
+++ b/clang-format.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Seems that the version of clang-format on some systems is outdated; use the externals-clasp one.
+
+[ -e 'local.config' ] || echo "Please set up local.config before running clang-format.sh"
+
+# Horrible hack to read local.config into bash
+eval $(perl -ne 'if (/^export\s+[A-Z_]+ /) {s/\$\K\((.*?)\)/{$1}/g;s/\s+=\s+/=/;print "$_\n"}' local.config)
+
+# Hackety hack hack
+git ls-files src/ include/ \
+	| perl -ne 'chomp;print "$_\n" if -f $_ and (/\.[hc][hcp]?p?$/) and not -l;' \
+	| xargs -P$PJOBS -n1 --verbose ${EXTERNALS_SOURCE_DIR}/build/release/bin/clang-format -i

--- a/include/clasp/core/foundation.h
+++ b/include/clasp/core/foundation.h
@@ -38,11 +38,8 @@ THE SOFTWARE.
 //#define USE_BOEHM_MEMORY_MARKER
 #endif
 
-// clang-format off
-
 /*! Configure the application Clasp or Cando currently */
 #include APPLICATION_CONFIG
-// clang-format on
 
 /*! Old way of doing #= and ## used alists which are slow
   Switch to hash-tables to speed things up */


### PR DESCRIPTION
Added a `clang-format.sh` script to the repo root.
Removed guard comments in `include/clasp/core/foundation.h` as @drmeister stated that the file is now safe for `clang-format`.

`.clang-format` configuration file was merged by @drmeister in b36cdc50fbf22467085bd1c9d17c9c3c4abbabcc