### PR TITLE
Fix makefile assumptions and surprising behaviour

### DIFF
--- a/makefile
+++ b/makefile
@@ -220,7 +220,7 @@ boehm-setup:
 		CXX=$(BOEHM_CXX) \
                 CFLAGS="-DUSE_MMAP -g" \
 		PKG_CONFIG_PATH=$(CLASP_APP_RESOURCES_LIB_COMMON_DIR)/lib/pkgconfig/ \
-		./configure --enable-shared=yes --enable-static=yes --enable-handle-fork --enable-cplusplus --prefix=$(CLASP_APP_RESOURCES_LIB_COMMON_DIR);)
+		./configure --enable-shared=yes --enable-static=yes --enable-handle-fork --enable-cplusplus --prefix=$(CLASP_APP_RESOURCES_LIB_COMMON_DIR) --with-libatomic-ops=yes;)
 
 boehm-compile:
 	(cd $(BOEHM_SOURCE_DIR); make -j$(PJOBS) | tee _boehm.log)

--- a/makefile
+++ b/makefile
@@ -2,10 +2,9 @@
 # -*- mode: GNUmakefile; indent-tabs-mode: t -*-
 # Cleaned up by Shinmera October 13, 2015
 
-export CLASP_HOME := $(or $(wildcard $(CLASP_HOME)),\
-                          $(shell pwd))
-
 include $(wildcard $(CLASP_HOME)/local.config)
+
+export CLASP_HOME ?= $(shell pwd)
 
 export PJOBS ?= 1
 

--- a/makefile
+++ b/makefile
@@ -66,6 +66,9 @@ export LLVM_CONFIG_DEBUG ?= $(or $(wildcard $(EXTERNALS_CLASP_DIR)/build/debug/b
                                  $(LLVM_CONFIG))
 
 export LLVM_BIN_DIR ?= $(shell $(LLVM_CONFIG_RELEASE) --bindir)
+# Not always the same as LLVM_BIN_DIR!
+export CLANG_BIN_DIR ?= $(if $(wildcard $(LLVM_BIN_DIR)/clang),$(LLVM_BIN_DIR),$(dir $(or $(call pathsearch, clang),\
+                                        $(error Could not find clang.))))
 
 export CLASP_INTERNAL_BUILD_TARGET_DIR ?= $(shell pwd)/build/clasp
 
@@ -109,8 +112,8 @@ ifeq ($(TARGET_OS),Darwin)
 endif
 
 ifeq ($(TARGET_OS),Linux)
-  export BOEHM_CC = $(LLVM_BIN_DIR)/clang
-  export BOEHM_CXX = $(LLVM_BIN_DIR)/clang++
+  export BOEHM_CC = $(CLANG_BIN_DIR)/clang
+  export BOEHM_CXX = $(CLANG_BIN_DIR)/clang++
 endif
 
 include_flags := $(foreach dir,$(INCLUDE_DIRS),$(and $(wildcard $(dir)),-I$(dir)))
@@ -468,6 +471,7 @@ print-config:
 	$(call varprint, LLVM_CONFIG_DEBUG)
 	$(call varprint, LLVM_CONFIG_RELEASE)
 	$(call varprint, LLVM_BIN_DIR)
+	$(call varprint, CLANG_BIN_DIR)
 	$(call varprint, GIT_COMMIT)
 	$(call varprint, CLASP_VERSION)
 	$(call varprint, CLASP_INTERNAL_BUILD_TARGET_DIR)

--- a/makefile
+++ b/makefile
@@ -134,8 +134,15 @@ ifneq ($(CXXFLAGS),)
   export USE_CXXFLAGS := cxxflags=$(CXXFLAGS)
 endif
 
+ifeq ($(NO_COLOR),)
+TPUT = $(call pathsearch,tput)
+ifneq ($(TPUT),)
+  COLOR_GREEN = $(shell $(TPUT) setaf 2 2>/dev/null)
+  COLOR_RESET = $(shell $(TPUT) sgr0    2>/dev/null)
+endif
+endif
 define varprint
-	@echo -e "\033[0;32m$(strip $(1))\033[0m: $($(strip $(1)))"
+	@echo -e "$(COLOR_GREEN)$(strip $(1))$(COLOR_RESET): $($(strip $(1)))"
 endef
 
 all:


### PR DESCRIPTION
Replace `$(wildcard)` with actual `PATH` searching, force external `libatomic_ops` (prevents `bwdgc` from trying to build `src/boehm/bwdgc/libatomic_ops`, which does not exist.
Simplify `CLASP_HOME` behaviour, which currently silently switches to `pwd` if it is set but does not exist; this violates principle of least surprise.
Replace the assumption of clang and llvm having the same `BINDIR`.
Replace hard-coded ANSI color codes with `tput`; disabled if `NO_COLOR` is set (or `TERM="dumb"`)

These changes were tested with a full build on [NixOS](//nixos.org)+[Autobuild](/shinmera/autobuild).