### PR TITLE
Optimize #x=/#x#.

### DIFF
--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -1057,9 +1057,8 @@ void CoreExposer::define_essential_globals(Lisp_sp lisp) {
   cl::_sym_STARterminal_ioSTAR->defparameter(terminal);
   _sym_STARsystem_defsetf_update_functionsSTAR->defparameter(_Nil<T_O>());
   cl::_sym_STARmacroexpand_hookSTAR->defparameter(_sym_macroexpand_default);
-  _sym_STARsharp_equal_final_tableSTAR->defparameter(HashTable_O::create(cl::_sym_eq));
-  _sym_STARsharp_equal_temp_tableSTAR->defparameter(HashTable_O::create(cl::_sym_eq));
-  _sym_STARsharp_equal_repl_tableSTAR->defparameter(HashTable_O::create(cl::_sym_eq));
+  _sym_STARsharp_equal_final_tableSTAR->defparameter(_Nil<T_O>());
+
   _sym__PLUS_activationFrameNil_PLUS_->defconstant(_Nil<T_O>());
   _sym__PLUS_executableName_PLUS_->defconstant(Str_O::create(EXECUTABLE_NAME));
   SYMBOL_SC_(CorePkg, cArgumentsLimit);

--- a/src/core/lispReader.cc
+++ b/src/core/lispReader.cc
@@ -657,10 +657,7 @@ List_sp read_list(T_sp sin, char end_char, bool allow_consing_dot) {
   }
 }
 
-/*! Used when USE_SHARP_EQUAL_HASH_TABLES is on */
 SYMBOL_SC_(CorePkg, STARsharp_equal_final_tableSTAR);
-SYMBOL_SC_(CorePkg, STARsharp_equal_temp_tableSTAR);
-SYMBOL_SC_(CorePkg, STARsharp_equal_repl_tableSTAR);
 
 __thread unsigned int read_lisp_object_recursion_depth = 0;
 struct increment_read_lisp_object_recursion_depth {
@@ -703,12 +700,7 @@ T_sp read_lisp_object(T_sp sin, bool eofErrorP, T_sp eofValue, bool recursiveP) 
     }
   } else {
     increment_read_lisp_object_recursion_depth::reset();
-    DynamicScopeManager scope(_sym_STARsharp_equal_final_tableSTAR,
-                              HashTableEql_O::create(40, make_fixnum(4000), 0.8));
-    scope.pushSpecialVariableAndSet(_sym_STARsharp_equal_temp_tableSTAR,
-                                    HashTableEql_O::create(40, make_fixnum(4000), 0.8));
-    scope.pushSpecialVariableAndSet(_sym_STARsharp_equal_repl_tableSTAR,
-                                    HashTableEq_O::create(40, make_fixnum(4000), 0.8));
+    DynamicScopeManager scope(_sym_STARsharp_equal_final_tableSTAR, _Nil<T_O>());
     result = read_lisp_object(sin, eofErrorP, eofValue, true);
   }
   if (result.nilp())

--- a/src/core/readtable.cc
+++ b/src/core/readtable.cc
@@ -149,8 +149,6 @@ CL_DEFUN T_mv cl__set_macro_character(Character_sp ch, T_sp func_desig, T_sp non
 
 SYMBOL_EXPORT_SC_(KeywordPkg, constituent_character);
 SYMBOL_EXPORT_SC_(KeywordPkg, whitespace_character);
-SYMBOL_SC_(CorePkg, STARsharp_equal_alistSTAR);
-SYMBOL_SC_(CorePkg, STARsharp_sharp_alistSTAR);
 SYMBOL_SC_(CorePkg, STARconsing_dot_allowedSTAR);
 SYMBOL_SC_(CorePkg, STARconsing_dotSTAR);
 SYMBOL_SC_(CorePkg, STARpreserve_whitespace_pSTAR);


### PR DESCRIPTION
Instead of using a symbol as a tag marking yet unread objects use a
structure.
It is more compact, exactly identifiable as a tag and can store the
read value directly instead of using an additional list.