### PR TITLE
Add core:*stack-top-hint* for better backtraces.

### DIFF
--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -721,7 +721,7 @@ SYMBOL_EXPORT_SC_(CorePkg, instance);
 SYMBOL_SC_(CorePkg, all_keys);
 
 SYMBOL_EXPORT_SC_(KeywordPkg, changed);
-
+SYMBOL_EXPORT_SC_(CorePkg,STARstack_top_hintSTAR);
 
 void testConses() {
   printf("%s:%d Testing Conses and iterators\n", __FILE__, __LINE__);

--- a/src/lisp/kernel/clos/conditions.lsp
+++ b/src/lisp/kernel/clos/conditions.lsp
@@ -851,6 +851,8 @@ memory limits before executing the program again."))
 			for value in values
 			collect (assert-prompt place-name value)))))))
 
+(defvar *stack-top-hint* nil)
+
 ;;; ----------------------------------------------------------------------
 ;;; ECL's interface to the toplevel and debugger
 
@@ -870,7 +872,8 @@ bstrings."
   (declare (inline apply) ;; So as not to get bogus frames in debugger
 ;;	   #-ecl-min (c::policy-debug-ihs-frame)
 	   )
-  (let ((condition (coerce-to-condition datum args 'simple-error 'error)))
+  (let ((condition (coerce-to-condition datum args 'simple-error 'error))
+        (*stack-top-hint* (1- (ihs-top))))
     (cond
       ((eq t continue-string)
        ; from CEerror; mostly allocation errors
@@ -895,9 +898,8 @@ bstrings."
 	       (if used-restart continue-string rv)))
 	   (if used-restart t rv))))
       (t
-       (progn
-	 (signal condition)
-	 (invoke-debugger condition))))))
+       (signal condition)
+       (invoke-debugger condition)))))
 
 (defun sys::tpl-continue-command (&rest any)
   (apply #'invoke-restart 'continue any))


### PR DESCRIPTION
Bind it to (1- (ihs-top)) in core:universal-error-handler which will
point to where the error actually happened.