### PR TITLE
s/ecl-min/clasp-min/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ boost_build_v2/engine/bootstrap
 build/
 projects/
 build2/
+/.lock-waf_linux_build

--- a/src/core/arrayObjects.cc
+++ b/src/core/arrayObjects.cc
@@ -196,7 +196,7 @@ LongLongInt ArrayObjects_O::setDimensions(List_sp dim, T_sp initialElement) {
   _OF();
   LongLongInt elements = 1;
   int newRank = cl__length(dim);
-  if (newRank >= CLASP_ARRAY_RANK_LIMIT) {
+  if (newRank > CLASP_ARRAY_RANK_LIMIT) {
     SIMPLE_ERROR(BF("Maximum rank is %d") % CLASP_ARRAY_RANK_LIMIT);
   }
   this->_Dimensions.resize(newRank);

--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -320,7 +320,7 @@ CL_DEFUN T_mv core__mangle_name(Symbol_sp sym, bool is_function) {
 
 CL_LAMBDA();
 CL_DECLARE();
-CL_DOCSTRING("startupImagePathname - returns a pathname based on *features* :ECL-MIN, :USE-MPS, :BCLASP");
+CL_DOCSTRING("startupImagePathname - returns a pathname based on *features* :CLASP-MIN, :USE-MPS, :BCLASP");
 CL_DEFUN T_sp core__startup_image_pathname() {
   stringstream ss;
   ss << "build:";

--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -223,7 +223,7 @@ CL_DECLARE();
 CL_DOCSTRING("Print info about booting");
 CL_DEFUN void core__help_booting() {
   printf("Useful *features*\n"
-         ":ecl-min (should be clasp-min),  :bclasp, :cclasp  -- Tells Clasp what stage it's in and where to get its init file.\n"
+         ":clasp-min,  :bclasp, :cclasp  -- Tells Clasp what stage it's in and where to get its init file.\n"
          ":notify-on-compile (core:*notify-on-compile*) - prints messages whenever COMPILE is invoked at startup\n"
          ":trace-startup (core:*trace-startup*) - prints messages and timing for running the main function of the compiled code of each system file at startup\n"
          ":debug-startup (core:*debug-startup*) - prints a message and timing for running each top level function\n"

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -270,7 +270,7 @@ SYMBOL_EXPORT_SC_(KeywordPkg, cclasp);
 SYMBOL_EXPORT_SC_(KeywordPkg, bclasp);
 SYMBOL_EXPORT_SC_(KeywordPkg, load);
 SYMBOL_EXPORT_SC_(KeywordPkg, eval);
-SYMBOL_EXPORT_SC_(KeywordPkg, ecl_min);
+SYMBOL_EXPORT_SC_(KeywordPkg, clasp_min);
 SYMBOL_EXPORT_SC_(KeywordPkg, use_mps);
 SYMBOL_EXPORT_SC_(KeywordPkg, use_boehmdc);
 SYMBOL_EXPORT_SC_(KeywordPkg, use_boehm);

--- a/src/lisp/kernel/clasp-builder.lsp
+++ b/src/lisp/kernel/clasp-builder.lsp
@@ -28,7 +28,7 @@
 
 
 (defun remove-stage-features ()
-  (setq *features* (recursive-remove-from-list :ecl-min *features*))
+  (setq *features* (recursive-remove-from-list :clasp-min *features*))
   (setq *features* (recursive-remove-from-list :clos *features*))
   (setq *features* (recursive-remove-from-list :aclasp *features*))
   (setq *features* (recursive-remove-from-list :bclasp *features*))
@@ -37,11 +37,11 @@
 (export '(aclasp-features with-aclasp-features))
 (defun aclasp-features ()
   (remove-stage-features)
-  (setq *features* (list* :aclasp :ecl-min *features*)))
+  (setq *features* (list* :aclasp :clasp-min *features*)))
 (core:fset 'with-aclasp-features
             #'(lambda (whole env)
                 (let* ((body (cdr whole)))
-                  `(let ((*features* (list* :aclasp :ecl-min *features*)))
+                  `(let ((*features* (list* :aclasp :clasp-min *features*)))
                      ,@body)))
             t)
 

--- a/src/lisp/kernel/clos/conditions.lsp
+++ b/src/lisp/kernel/clos/conditions.lsp
@@ -871,8 +871,8 @@ that caused the error.  CONTINUE-FORMAT-STRING and ERROR-FORMAT-STRING are the
 format strings of the error message.  ARGS are the arguments to the format
 bstrings."
   (declare (inline apply) ;; So as not to get bogus frames in debugger
-;;	   #-ecl-min (c::policy-debug-ihs-frame)
-	   )
+	   #-(or ecl-min clasp)
+           (c::policy-debug-ihs-frame))
   (let ((condition (coerce-to-condition datum args 'simple-error 'error))
         (*stack-top-hint* (1- (ihs-top))))
     (cond

--- a/src/lisp/kernel/cmp/compilefile.lsp
+++ b/src/lisp/kernel/cmp/compilefile.lsp
@@ -79,8 +79,8 @@
 (defvar *compilation-messages* nil)
 (defvar *compilation-warnings-p* nil)
 (defvar *compilation-failures-p* nil)
-         #+ecl-min (progn ,@body)
-         #-ecl-min (handler-bind
+         #+clasp-min (progn ,@body)
+         #-clasp-min (handler-bind
                        ((error #'(lambda (c)
                                    (invoke-restart 'record-failure c)))
                         (warning #'(lambda (c)

--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -1,4 +1,4 @@
-;; Set features :ecl-min for minimal system without CLOS
+;; Set features :clasp-min for minimal system without CLOS
 ;; :clos to compile with CLOS
 ;;
 

--- a/src/lisp/kernel/lsp/arraylib.lsp
+++ b/src/lisp/kernel/lsp/arraylib.lsp
@@ -168,20 +168,22 @@ row-major order."
 (defun bit (bit-array &rest indices)
   "Args: (bit-array &rest indexes)
 Returns the bit of BIT-ARRAY specified by INDEXes."
-  (declare #+ecl(array bit-array) ;; FIXME! Should be (simple-array bit)
-           #+clasp(type (simple-array bit) bit-array)
+  (declare #+ecl (array bit-array) ;; FIXME! Should be (simple-array bit)
+           #+clasp (type (simple-array bit) bit-array)
            (ext:check-arguments-type))
-  #+(and clasp (not ecl-min))(check-type bit-array (simple-array bit))
+  #+(and clasp (not clasp-min))
+  (check-type bit-array (simple-array bit))
   (row-major-aref bit-array (row-major-index-inner bit-array indices)))
 
 
 (defun sbit (bit-array &rest indices)
   "Args: (simple-bit-array &rest subscripts)
 Returns the specified bit in SIMPLE-BIT-ARRAY."
-  (declare #+ecl(array bit-array) ;; FIXME! Should be (simple-array bit)
-           #+clasp(type (simple-array bit) bit-array)
+  (declare #+ecl (array bit-array) ;; FIXME! Should be (simple-array bit)
+           #+clasp (type (simple-array bit) bit-array)
            (ext:check-arguments-type))
-  #+(and clasp (not ecl-min))(check-type bit-array (simple-array bit))
+  #+(and clasp (not clasp-min))
+  (check-type bit-array (simple-array bit))
   (row-major-aref bit-array (row-major-index-inner bit-array indices)))
 
 

--- a/src/lisp/kernel/lsp/assert.lsp
+++ b/src/lisp/kernel/lsp/assert.lsp
@@ -17,7 +17,7 @@
   (format *query-io* "~&Type a form to be evaluated:~%")
   (list (eval (read *query-io*))))
 
-#-ecl-min
+#-clasp-min
 (defun wrong-type-argument (object type &optional place function)
   #-ecl-min
   (declare (policy-debug-ihs-frame))
@@ -55,7 +55,7 @@ value is used to indicate the expected type in the error message."
 	 (setf ,place (do-check-type ,aux ',type ',type-string ',place)))
        nil)))
 
-#-ecl-min
+#-clasp-min
 (defun do-check-type (value type type-string place)
   (tagbody again
      (unless (typep value type)
@@ -118,7 +118,7 @@ signals an error."
        (case ,key ,@clauses
 	 (t (si::ecase-error ,key ',(accumulate-cases clauses nil)))))))
 
-#-ecl-min
+#-clasp-min
 (defun ccase-error (keyform key values)
   (restart-case (error 'CASE-FAILURE
 		       :name 'CCASE
@@ -200,7 +200,7 @@ the last FORM.  If not, signals an error."
        )
    )
 
-#-ecl-min
+#-clasp-min
 (defun ctypecase-error (keyplace value types)
   (restart-case (error 'CASE-FAILURE
 		       :name 'CTYPECASE

--- a/src/lisp/kernel/lsp/cmuutil.lsp
+++ b/src/lisp/kernel/lsp/cmuutil.lsp
@@ -136,7 +136,7 @@
 (defmacro with-unique-names (symbols &body body)
   `(let* ,(mapcar (lambda (symbol)
                     (let* ((symbol-name (symbol-name symbol))
-                           (stem symbol-name)
+                           (stem symbol-name))
                       `(,symbol (gensym ,stem))))
                   symbols)
      ,@body))

--- a/src/lisp/kernel/lsp/cmuutil.lsp
+++ b/src/lisp/kernel/lsp/cmuutil.lsp
@@ -10,7 +10,7 @@
 
 (eval-when (:compile-toplevel  :execute   :load-toplevel)
   
-  #+ecl-min
+  #+(or ecl-min clasp-min)
   (defmacro handler-bind (bindings &body body)
     `(progn ,@body))
   
@@ -136,15 +136,7 @@
 (defmacro with-unique-names (symbols &body body)
   `(let* ,(mapcar (lambda (symbol)
                     (let* ((symbol-name (symbol-name symbol))
-;;                           #+ecl-min
                            (stem symbol-name)
-#||                           #-ecl-min
-                           (stem (if (every #'alpha-char-p symbol-name)
-                                     nil
-                                     symbol-name
-                                     (concatenate 'string symbol-name "-")))
-||#
-			   )
                       `(,symbol (gensym ,stem))))
                   symbols)
      ,@body))

--- a/src/lisp/kernel/lsp/defmacro.lsp
+++ b/src/lisp/kernel/lsp/defmacro.lsp
@@ -14,7 +14,7 @@
 
 (in-package "SYSTEM")
 
-#+ecl-min
+#+(or ecl-min clasp-min)
 (si::fset 'push
 	  (function 
 	   #+ecl(ext::lambda-block push (args env)
@@ -30,7 +30,7 @@
 	   )
 	  t)
 
-#+ecl-min
+#+(or ecl-min clasp-min)
 (si::fset 'pop
 	  (function 
 	   #+ecl(ext::lambda-block pop (args env)
@@ -50,7 +50,7 @@
 	   )
 	  t)
 
-#+ecl-min
+#+(or ecl-min clasp-min)
 (si::fset 'incf
 	  (function 
 	   #+ecl(ext::lambda-block incf (args env)
@@ -70,7 +70,7 @@
 	   )
 	  t)
 
-#+ecl-min
+#+(or ecl-min clasp-min)
 (si::fset 'decf
 	  (function 
 	   #+ecl(ext::lambda-block decf (args env)
@@ -318,7 +318,7 @@
                 ppn
                 doc)))))
 
-#+ecl-min
+#+(or ecl-min clasp-min)
 (si::fset 'defmacro
 	  (function 
 	   #+ecl(ext::lambda-block defmacro (def env)

--- a/src/lisp/kernel/lsp/describe.lsp
+++ b/src/lisp/kernel/lsp/describe.lsp
@@ -137,7 +137,7 @@
                       Type ? followed by #\\Newline for help.~%")
 	 ))))
 
-;;#+ecl-min
+#+ecl-min
 (defmacro inspect-recursively (label object &optional place)
   (if place
       `(multiple-value-bind (update-flag new-value)
@@ -147,7 +147,7 @@
              (princ "Not updated.")
              (terpri))))
 
-;;#+ecl-min
+#+ecl-min
 (defmacro inspect-print (label object &optional place)
   (if place
       `(multiple-value-bind (update-flag new-value)

--- a/src/lisp/kernel/lsp/epilogue-aclasp.lsp
+++ b/src/lisp/kernel/lsp/epilogue-aclasp.lsp
@@ -1,4 +1,4 @@
-#+(or ecl-min aclasp)
+#+(or clasp-min aclasp)
 (eval-when (:load-toplevel)
   (process-command-line-load-eval-sequence)
   (core::select-package :core)

--- a/src/lisp/kernel/lsp/epilogue.lsp
+++ b/src/lisp/kernel/lsp/epilogue.lsp
@@ -1,4 +1,4 @@
-#+ecl-min(eval-when (:load-toplevel)
+#+clasp-min(eval-when (:load-toplevel)
            (process-command-line-load-eval-sequence)
            (core::select-package :core)
            (let ((core:*use-interpreter-for-eval* nil))

--- a/src/lisp/kernel/lsp/evalmacros.lsp
+++ b/src/lisp/kernel/lsp/evalmacros.lsp
@@ -230,7 +230,7 @@ terminated by a non-local exit."
 		  (block ,(si::function-block-name name) ,@body))))
 ; assignment
 
-#-ecl-min
+#-clasp-min
 (defmacro psetq (&rest args)
   "Syntax: (psetq {var form}*)
 Similar to SETQ, but evaluates all FORMs first, and then assigns each value to

--- a/src/lisp/kernel/lsp/foundation.lsp
+++ b/src/lisp/kernel/lsp/foundation.lsp
@@ -70,7 +70,7 @@
       t)
 
 #| --- loose this - its in evalmacros where ecl had it |#
-#+ecl-min
+#+clasp-min
 (si::fset 'psetq #'(lambda (whole env)
 		     "Syntax: (psetq {var form}*)
 Similar to SETQ, but evaluates all FORMs first, and then assigns each value to

--- a/src/lisp/kernel/lsp/helpfile.lsp
+++ b/src/lisp/kernel/lsp/helpfile.lsp
@@ -250,15 +250,15 @@ strings."
               "EXT")
 (si::fset 'ext:optional-annotation
           (function 
-	   #+ecl(ext:lambda-block ext:optional-annotation (whole env)
-				  (declare (ignore env #-ecl-min whole))
-				  #+ecl-min
-				  `(ext:annotate ,@(rest whole)))
-	   #+clasp(lambda (whole env)
-	    (declare (ignore env #-ecl-min whole) 
+	   #+ecl
+           #'(ext:lambda-block ext:optional-annotation (whole env)
+              (declare (ignore env))
+              `(ext:annotate ,@(rest whole)))
+	   #+clasp
+           (lambda (whole env)
+	    (declare (ignore env #-clasp-min whole)
 		     (core:lambda-name ext:optional-annotation))
-	      #+ecl-min `(ext:annotate ,@(rest whole)))
-	   )
+            #+clasp-min `(ext:annotate ,@(rest whole))))
 	  t)
 
 (defun default-annotation-logic (source-loc definition output-form

--- a/src/lisp/kernel/lsp/mislib.lsp
+++ b/src/lisp/kernel/lsp/mislib.lsp
@@ -155,7 +155,7 @@ Evaluates FORM, outputs the realtime and runtime used for the evaluation to
 (defconstant month-startdays #(0 31 59 90 120 151 181 212 243 273 304 334 365))
 
 
-#-ecl-min
+#-(or ecl-min clasp-min)
 (defun get-local-time-zone ()
   "Returns the number of hours West of Greenwich for the local time zone."
   (declare (si::c-local))
@@ -268,7 +268,7 @@ Universal Time UT, which defaults to the current time."
 			#.(encode-universal-time 0 0 0 1 1 2032 0)
 			#.(encode-universal-time 0 0 0 1 1 2033 0))
 		    (- universal-time (encode-universal-time 0 0 0 1 1 year 0) utc-1-1-1970)))))
-    #-ecl-min
+    #-(or ecl-min clasp-min)
     (ffi::c-inline core:unix-daylight-saving-time (unix-time) (:unsigned-long) :bool "
 {
 	time_t when = (#0);

--- a/src/lisp/kernel/lsp/numlib.lsp
+++ b/src/lisp/kernel/lsp/numlib.lsp
@@ -15,7 +15,7 @@
 
 (in-package "SYSTEM")
 
-#+(or) ;; #-ecl-min
+#-(or ecl-min clasp)
 (ffi:clines "#include <math.h>")
 
 #.
@@ -34,8 +34,8 @@
 	 (/= (float 1 x) (+ (float 1 x) x)))
        (epsilon- (x)
 	 (/= (float 1 x) (- (float 1 x) x))))
-;;  #+ecl-min
-;;  (si::trap-fpe 'last nil)
+  #+(and ecl-min (not clasp))
+  (si::trap-fpe 'last nil)
   `(eval-when (compile load eval)
     (defconstant short-float-epsilon
       ,(binary-search #'epsilon+ (coerce 0 'short-float) (coerce 1 'short-float))
@@ -126,8 +126,8 @@ zero.  Otherwise, returns the value of (/ NUMBER (ABS NUMBER))"
 Returns a complex number whose realpart and imagpart are the values of (COS
 RADIANS) and (SIN RADIANS) respectively."
   (exp (* imag-one x)))
-#||
-#-ecl-min
+
+#-(or ecl-min clasp)
 (eval-when (:compile-toplevel)
   (defmacro c-num-op (name arg)
     #+long-float
@@ -138,13 +138,14 @@ RADIANS) and (SIN RADIANS) respectively."
     `(ffi::c-inline (,arg) (:double) :double
 		    ,(format nil "~a(#0)" name)
 		    :one-liner t)))
-||#
+
 (defun asin (x)
   "Args: (number)
 Returns the arc sine of NUMBER."
-  (if #+ecl-min t #-ecl-min (complexp x)
+  (if #+(or ecl-min clasp-min) t
+      #-(or ecl-min clasp-min) (complexp x)
       (complex-asin x)
-      #-ecl-min
+      #-(or ecl-min clasp-min)
       (let* ((x (float x))
 	     (xr (float x 1l0)))
 	(declare (long-float xr))
@@ -165,9 +166,10 @@ Returns the arc sine of NUMBER."
 (defun acos (x)
   "Args: (number)
 Returns the arc cosine of NUMBER."
-  (if #+ecl-min t #-ecl-min (complexp x)
+  (if #+(or ecl-min clasp-min) t
+      #-(or ecl-min clasp-min) (complexp x)
       (complex-acos x)
-      #-ecl-min
+      #-(or ecl-min clasp-min)
       (let* ((x (float x))
 	     (xr (float x 1l0)))
 	(declare (long-float xr))
@@ -184,20 +186,17 @@ Returns the arc cosine of NUMBER."
     (complex (* 2 (atan (realpart sqrt-1-z) (realpart sqrt-1+z)))
 	     (asinh (imagpart (* (conjugate sqrt-1+z)
 				 sqrt-1-z))))))
-#||
-#+(and (not ecl-min) win32 (not mingw32))
+#+(and (not ecl-min) win32 (not mingw32) (not clasp))
 (progn
   (ffi:clines "double asinh(double x) { return log(x+sqrt(1.0+x*x)); }")
   (ffi:clines "double acosh(double x) { return log(x+sqrt((x-1)*(x+1))); }")
   (ffi:clines "double atanh(double x) { return log((1+x)/(1-x))/2; }"))
 
-#+(and long-float (not ecl-min) win32 (not mingw32))
+#+(and long-float (not ecl-min) win32 (not mingw32) (not clasp))
 (progn
   (ffi:clines "double asinhl(long double x) { return logl(x+sqrtl(1.0+x*x)); }")
   (ffi:clines "double acoshl(long double x) { return logl(x+sqrtl((x-1)*(x+1))); }")
   (ffi:clines "double atanhl(long double x) { return logl((1+x)/(1-x))/2; }"))
-||#
-
 
 
 ;; Ported from CMUCL
@@ -205,27 +204,32 @@ Returns the arc cosine of NUMBER."
   "Args: (number)
 Returns the hyperbolic arc sine of NUMBER."
   ;(log (+ x (sqrt (+ 1.0 (* x x)))))
-  (if #+(or ecl-min) t #-(or ecl-min) (complexp x)
+  (if #+(or ecl-min clasp-min) t
+      #-(or ecl-min clasp-min) (complexp x)
       (let* ((iz (complex (- (imagpart x)) (realpart x)))
 	     (result (complex-asin iz)))
 	(complex (imagpart result)
 		 (- (realpart result))))
-      #-(or ecl-min)
-      (float #+ecl(c-num-op "asinh" x) #+clasp(core:num-op-asinh x) (float x))))
+      #-(or ecl-min clasp-min)
+      (float #+ecl (c-num-op "asinh" x)
+             #+clasp (core:num-op-asinh x)
+             (float x))))
 
 ;; Ported from CMUCL
 (defun acosh (x)
   "Args: (number)
 Returns the hyperbolic arc cosine of NUMBER."
   ;(log (+ x (sqrt (* (1- x) (1+ x)))))
-  (if #+(or ecl-min) t #-(or ecl-min) (complexp x)
+  (if #+(or ecl-min clasp-min) t
+      #-(or ecl-min clasp-min) (complexp x)
       (complex-acosh x)
-      #-(or ecl-min)
+      #-(or ecl-min clasp-min)
       (let* ((x (float x))
 	     (xr (float x 1d0)))
 	(declare (double-float xr))
 	(if (<= 1.0 xr)
-	    (float #+ecl(c-num-op "acosh" xr) #+clasp(core:num-op-acosh xr) (float x))
+	    (float #+ecl (c-num-op "acosh" xr)
+                   #+clasp (core:num-op-acosh xr) (float x))
 	    (complex-acosh x)))))
 
 (defun complex-acosh (z)
@@ -240,14 +244,17 @@ Returns the hyperbolic arc cosine of NUMBER."
   "Args: (number)
 Returns the hyperbolic arc tangent of NUMBER."
   ;(/ (- (log (1+ x)) (log (- 1 x))) 2)
-  (if #+(or ecl-min) t #-(or ecl-min) (complexp x)
+  (if #+(or ecl-min clasp-min) t
+      #-(or ecl-min clasp-min) (complexp x)
       (complex-atanh x)
-      #-(or ecl-min)
+      #-(or ecl-min clasp-min)
       (let* ((x (float x))
 	     (xr (float x 1d0)))
 	(declare (double-float xr))
 	(if (and (<= -1.0 xr) (<= xr 1.0))
-	    (float #+ecl(c-num-op "atanh" xr) #+clasp(core:num-op-atanh xr) (float x))
+	    (float #+ecl (c-num-op "atanh" xr)
+                   #+clasp(core:num-op-atanh xr)
+                   (float x))
 	    (complex-atanh x)))))
 
 (defun complex-atanh (z)

--- a/src/lisp/kernel/lsp/pprint.lsp
+++ b/src/lisp/kernel/lsp/pprint.lsp
@@ -1622,6 +1622,6 @@
   (setf *print-pprint-dispatch* (copy-pprint-dispatch nil))
   (setf (first (cdr si::+io-syntax-progv-list+)) *initial-pprint-dispatch*)
   (setf (first (cdr si::+ecl-syntax-progv-list+)) *initial-pprint-dispatch*)
-#-ecl-min
+  #-(or ecl-min clasp-min)
   (setf *print-pretty* t)
 )

--- a/src/lisp/kernel/lsp/predlib.lsp
+++ b/src/lisp/kernel/lsp/predlib.lsp
@@ -657,7 +657,7 @@ Returns T if X belongs to TYPE; NIL otherwise."
 		  (when (eq (class-name c) class)
 		    (return t)))))))))
 
-#+(and clos ecl-min (not clasp))
+#+(and clos ecl-min)
 (defun clos::classp (foo)
   (declare (ignore foo))
   nil)

--- a/src/lisp/kernel/lsp/prologue.lsp
+++ b/src/lisp/kernel/lsp/prologue.lsp
@@ -1,8 +1,8 @@
-#+ecl-min
+#+clasp-min
 (progn
   (if (member :interactive *features*)
       (progn
-        (setq *features* (cons :ecl-min *features*))
+        (setq *features* (cons :clasp-min *features*))
         (setq *features* (cons :aclasp *features*))
         (bformat t "Starting %s ... loading image... it takes a few seconds\n"
                  (lisp-implementation-version)))))

--- a/src/lisp/kernel/lsp/seqlib.lsp
+++ b/src/lisp/kernel/lsp/seqlib.lsp
@@ -15,19 +15,17 @@
 
 (in-package "SYSTEM")
 
-#|
 #+ecl-min
 (eval-when (:execute)
   (load (merge-pathnames "seqmacros.lsp" *load-truename*)))
 
-#-ecl-min
+#-(or ecl-min clasp)
 (eval-when (:compile-toplevel)
 (define-compiler-macro copy-subarray (&rest args)
   `(ffi:c-inline ,args (:object :fixnum :object :fixnum :fixnum) :void
                  "ecl_copy_subarray(#0,#1,#2,#3,#4)"
-                 :one-liner t))
-)
-|#
+                 :one-liner t)))
+
 (defun seqtype (sequence)
   (declare (si::c-local))
   (cond ((listp sequence) 'list)

--- a/src/main/link-bclasp.lsp
+++ b/src/main/link-bclasp.lsp
@@ -1,6 +1,6 @@
 (select-package :core)
 (load-system :start :min)
-(if (member :ecl-min *features*) (bclasp-features))
+(if (member :clasp-min *features*) (bclasp-features))
 (let ((*target-backend* (default-target-backend)))
   (load-system :init :all)
   (link-system :init :all (default-prologue-form '(:clos)) (default-epilogue-form)))

--- a/src/main/link-cclasp.lsp
+++ b/src/main/link-cclasp.lsp
@@ -2,7 +2,7 @@
 (make-package "CLASP-CLEAVIR-AST")
 (core::add-cleavir-to-*system-files*)
 (setq *features* (list* :cclasp :clos *features*))
-(setq *features* (core::recursive-remove-from-list :ecl-min *features*))
+(setq *features* (core::recursive-remove-from-list :clasp-min *features*))
 (setq *target-backend* (core::default-target-backend))
 (load-system :start :pre-inline :system *system-files* :load-bitcode t)
 

--- a/src/main/makefile
+++ b/src/main/makefile
@@ -14,7 +14,7 @@ ifneq ($(CLASP_INTERNAL_BUILD_TARGET_DIR),)
   BCLASP_BOEHM = bclasp-boehm-o
   CCLASP_BOEHMDC = $(CLASP_APP_EXECS)/boehmdc/release/bin/clasp
   CCLASP_BOEHM = cclasp-boehm-o
-  ACLASP_MPS = $(CLASP_APP_EXECS)/mps/release/bin/clasp -I -f ecl-min
+  ACLASP_MPS = $(CLASP_APP_EXECS)/mps/release/bin/clasp -I -f clasp-min
   BCLASP_MPS = $(CLASP_APP_EXECS)/mps/release/bin/clasp -f bclasp
   CCLASP_MPS = $(CLASP_APP_EXECS)/mps/release/bin/clasp
   CLASP_MPS = $(CLASP_APP_EXECS)/mps/release/bin/clasp
@@ -147,28 +147,28 @@ mps-debug-cxx-a:
 
 
 min-boehm-clean:
-	$(BCLASP_BOEHM) -I -f ecl-min -e "(clean-system :init :no-prompt t)" -e "(quit)"
+	$(BCLASP_BOEHM) -I -f clasp-min -e "(clean-system :init :no-prompt t)" -e "(quit)"
 
 bclasp-boehm-clean:
-	$(BCLASP_BOEHM) -I -f ecl-min -e "(bclasp-features)" -e "(clean-system :init :no-prompt t)" -e "(quit)"
+	$(BCLASP_BOEHM) -I -f clasp-min -e "(bclasp-features)" -e "(clean-system :init :no-prompt t)" -e "(quit)"
 
 cclasp-boehm-clean:
-	$(BCLASP_BOEHM) -I -f ecl-min -e "(cclasp-features)" -e "(clean-system :init :no-prompt t)" -e "(quit)"
+	$(BCLASP_BOEHM) -I -f clasp-min -e "(cclasp-features)" -e "(clean-system :init :no-prompt t)" -e "(quit)"
 
 min-boehm:
-	$(ICLASP_BOEHM) -I -f ecl-min -e "(compile-min)" -e "(link-min)" -e "(quit)"
+	$(ICLASP_BOEHM) -I -f clasp-min -e "(compile-min)" -e "(link-min)" -e "(quit)"
 
 min-mps:
-	$(CLASP_MPS) -I -f ecl-min -e "(compile-min)" -e "(link-min)" -e "(quit)"
+	$(CLASP_MPS) -I -f clasp-min -e "(compile-min)" -e "(link-min)" -e "(quit)"
 
 min-boehmdc:
-	$(CLASP_BOEHMDC) -I -f ecl-min -e "(compile-min)" -e "(link-min)" -e "(quit)"
+	$(CLASP_BOEHMDC) -I -f clasp-min -e "(compile-min)" -e "(link-min)" -e "(quit)"
 
 bclasp-boehmdc-bitcode:
-	$(BCLASP_BOEHMDC) -f ecl-min -e "(compile-bclasp)" -e "(quit)"
+	$(BCLASP_BOEHMDC) -f clasp-min -e "(compile-bclasp)" -e "(quit)"
 
 bclasp-boehmdc-fasl:
-	$(BCLASP_BOEHMDC) -f ecl-min -e "(link-bclasp)" -e "(quit)"
+	$(BCLASP_BOEHMDC) -f clasp-min -e "(link-bclasp)" -e "(quit)"
 
 bclasp-boehmdc:
 	make bclasp-boehmdc-bitcode
@@ -181,8 +181,8 @@ cclasp-boehmdc-fasl:
 	$(BCLASP_BOEHMDC) -e "(link-cclasp :force t)" -e "(quit)"
 
 link-all-boehmdc-fasl:
-	$(CLASP_BOEHMDC) -I -f ecl-min -e "(link-min)" -e "(quit)"
-	$(CLASP_BOEHMDC) -f ecl-min -e "(link-bclasp)" -e "(quit)"
+	$(CLASP_BOEHMDC) -I -f clasp-min -e "(link-min)" -e "(quit)"
+	$(CLASP_BOEHMDC) -f clasp-min -e "(link-bclasp)" -e "(quit)"
 	$(CLASP_BOEHMDC) -f bclasp -e "(link-cclasp)" -e "(quit)"
 	$(CLASP_BOEHMDC) -l "link_addons.lsp"
 
@@ -191,13 +191,13 @@ bclasp-boehm:
 	make bclasp-boehm-fasl
 
 bclasp-boehm-bitcode:
-	$(BCLASP_BOEHM) -f ecl-min -e "(compile-bclasp)" -e "(quit)"
+	$(BCLASP_BOEHM) -f clasp-min -e "(compile-bclasp)" -e "(quit)"
 
 bclasp-mps-bitcode:
-	$(CLASP_MPS) -f ecl-min -e "(compile-bclasp)" -e "(quit)"
+	$(CLASP_MPS) -f clasp-min -e "(compile-bclasp)" -e "(quit)"
 
 bclasp-boehm-fasl:
-	$(BCLASP_BOEHM) -f ecl-min -e "(link-bclasp)" -e "(quit)"
+	$(BCLASP_BOEHM) -f clasp-min -e "(link-bclasp)" -e "(quit)"
 
 
 bclasp-boehm-addons:
@@ -220,19 +220,19 @@ cclasp-boehm:
 	make cclasp-boehm-fasl
 
 cclasp-boehm-bitcode:
-	$(BCLASP_BOEHM) -f ecl-min -e "(compile-cclasp)" -e "(quit)"
+	$(BCLASP_BOEHM) -f clasp-min -e "(compile-cclasp)" -e "(quit)"
 
 cclasp-boehm-fasl:
-	$(BCLASP_BOEHM) -f ecl-min -e "(link-cclasp :force t)" -e "(quit)"
+	$(BCLASP_BOEHM) -f clasp-min -e "(link-cclasp :force t)" -e "(quit)"
 
 cclasp-mps-fasl:
 	$(BCLASP_MPS) -e "(link-cclasp :force t)" -e "(quit)"
 
 aclasp-mps-fasl:
-	$(CLASP_MPS) -I -f ecl-min -e "(link-min)" -e "(quit)"
+	$(CLASP_MPS) -I -f clasp-min -e "(link-min)" -e "(quit)"
 
 bclasp-mps-fasl:
-	$(CLASP_MPS) -f ecl-min -e "(link-bclasp)" -e "(quit)"
+	$(CLASP_MPS) -f clasp-min -e "(link-bclasp)" -e "(quit)"
 
 clasp-gc-interface:
 	$(BCLASP_BOEHM) -l "buildClaspGC.lsp"

--- a/wscript
+++ b/wscript
@@ -797,7 +797,7 @@ class compile_aclasp(Task.Task):
         print("In compile_aclasp %s -> %s" % (self.inputs[0],self.outputs[0]))
         cmd = [self.inputs[0].abspath(),
                "-I",
-               "-f", "ecl-min",
+               "-f", "clasp-min",
                "-f", "clasp-builder",
                "-f", "debug-run-clang",
                "-N",


### PR DESCRIPTION
This PR replaces all `ecl-min` references with appropriate feature conditions with `clasp-min` (improving compatibility of ECL and Clasp codebases)