### PR TITLE
Decode llvm-config output to a string in wscript

### DIFF
--- a/wscript
+++ b/wscript
@@ -411,7 +411,7 @@ def get_clasp_version(cfg):
 def call_llvm_config(cfg, *args):
     result = subprocess.Popen([cfg.env.LLVM_CONFIG_BINARY] + list(args), stdout = subprocess.PIPE).communicate()[0]
     assert len(result) > 0
-    return result.strip()
+    return result.strip().decode()
 
 def configure(cfg):
     def update_exe_search_path():


### PR DESCRIPTION
One reason the build doesn't work with Python 3 is that the output from
llvm-config is returned as bytes. This output is passed through some
functions, and then to Waf. Waf puts the strings into a compiler
command, as literals. The compiler (and the linker) see flags like
-lb'LLVMLTO', which make no sense.

Note that I haven't tested this with a full build yet, but it (combined with #309) at least makes `./waf configure` work correctly.

I'm keeping this separate from #309 because the changes introduced by #309 are a bit more intrusive than necessary to make Python 3 work, and might change.