### PR TITLE
Testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,9 +18,7 @@ boost_build_v2/bjam
 wscript.config
 boost_build_v2/engine/bin.linuxx86_64
 boost_build_v2/engine/bootstrap
-# ensure the build directory exists on checkout
 build/*
-!build/.gitkeep
 projects/
 build2/
 /.lock-waf_linux*_build

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,6 @@ boost_build_v2/bjam
 wscript.config
 boost_build_v2/engine/bin.linuxx86_64
 boost_build_v2/engine/bootstrap
-build/*
 projects/
 build2/
 /.lock-waf_linux*_build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: '2'
 services:
   # first, run: docker-compose run clasp-build
   # this will compile clasp and copy the Linux/ELF binary to ./build/clasp
+  # Note that this takes between 2 and 3 hours!
   clasp-build:
     image: clasp-build
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   clasp:
     image: clasp
     build:
-      context: ./build
+      context: .
       dockerfile: tools/dockerfiles/clasp/Dockerfile
     depends_on:
       - clasp-build
@@ -19,6 +19,6 @@ services:
     build:
       context: .
       dockerfile: tools/dockerfiles/clasp-build/Dockerfile
-    command: cp -v build/clasp /home/app/build/
+    entrypoint: cp -v build/clasp /home/app/build/
     volumes:
       - ./build:/home/app/build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,5 @@ services:
     build:
       context: .
       dockerfile: tools/dockerfiles/cando/Dockerfile
-    # depends_on:
-    #   - clasp
+    depends_on:
+      - clasp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '2'
 services:
-  # cando:
-  #   image: cando
-  #   build:
-  #     context: .
-  #     dockerfile: tools/dockerfiles/cando/Dockerfile
-  #   depends_on:
-  #     - clasp
+  cando:
+    image: cando
+    build:
+      context: .
+      dockerfile: tools/dockerfiles/cando/Dockerfile
+    # depends_on:
+    #   - clasp
   clasp:
     image: clasp
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,6 @@ services:
     build:
       context: .
       dockerfile: tools/dockerfiles/clasp-build/Dockerfile
-    entrypoint: cp -v build/clasp /home/app/build/
+    entrypoint: cp -v build/clasp /build/
     volumes:
-      - ./build:/home/app/build
+      - ./build:/build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,55 +1,24 @@
 version: '2'
 services:
-  cando-min-run:
-    image: cando-min-run
+  # cando:
+  #   image: cando
+  #   build:
+  #     context: .
+  #     dockerfile: tools/dockerfiles/cando/Dockerfile
+  #   depends_on:
+  #     - clasp
+  clasp:
+    image: clasp
     build:
-      context: .
-      dockerfile: tools/dockerfiles/cando-min-run/Dockerfile
+      context: ./build
+      dockerfile: tools/dockerfiles/clasp/Dockerfile
     depends_on:
-      - clasp-min-install
-  clasp-min-run:
-    image: clasp-min-run
+      - clasp-build
+  clasp-build:
+    image: clasp-build
     build:
       context: .
-      dockerfile: tools/dockerfiles/clasp-min-run/Dockerfile
-    depends_on:
-      - clasp-min-install
-  clasp-min-install:
-    image: clasp-min-install
-    build:
-      context: .
-      dockerfile: tools/dockerfiles/clasp-min-install/Dockerfile
-    depends_on:
-      - clasp-copy-out
-      - clasp-min-dependencies
-  clasp-min-dependencies:
-    image: clasp-min-dependencies
-    build:
-      context: tools/dockerfiles/clasp-min-dependencies
-    command: echo Done building clasp-min-dependencies.
-  clasp-copy-out:
-    image: clasp-copy-out
-    build:
-      context: .
-      dockerfile: tools/dockerfiles/clasp-copy-out/Dockerfile
+      dockerfile: tools/dockerfiles/clasp-build/Dockerfile
+    command: cp -v build/clasp /home/app/build/
     volumes:
-      - ./container:/tmp/clasp
-    command: cp -av install/ /tmp/clasp/
-    depends_on:
-      - clasp-full-build
-  clasp-full-build:
-    image: clasp-full-build
-    build:
-      context: .
-      dockerfile: tools/dockerfiles/clasp-full-build/Dockerfile
-      args:
-        CANDO_REVISION: dev
-    depends_on:
-      - clasp-dependencies
-  clasp-dependencies:
-    image: clasp-dependencies
-    build:
-      context: tools/dockerfiles/clasp-dependencies
-      args:
-        EXTERNALS_REVISION: master
-    command: echo Done building clasp-dependencies.
+      - ./build:/home/app/build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: .
       dockerfile: tools/dockerfiles/clasp-build/Dockerfile
-    entrypoint: cp -v build/clasp /build/
+    entrypoint: tar -cvzf /build/clasp.tgz -C /out/clasp .
     volumes:
       - ./build:/build
   # second, run: docker-compose build clasp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '2'
 services:
   # first, run: docker-compose run clasp-build
-  # this will compile clasp and copy the Linux/ELF binary to ./build/clasp
+  # this will compile clasp and copy it's build output ./build/clasp.tgz
   # Note that this takes between 2 and 3 hours!
   clasp-build:
     image: clasp-build
@@ -14,8 +14,8 @@ services:
     volumes:
       - ./build:/build
   # second, run: docker-compose build clasp
-  # this will "ADD ./build/clasp"
-  # into a smaller base image with the runtime dependencies
+  # This will start with a smaller base image, that has only the runtime
+  # dependencies, and unpack ./build/clasp.tgz into the directory /home/app
   clasp:
     image: clasp
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,9 @@
+# docker-compose uses this file to build clasp in 2 steps.
+# To compile clasp, you need to have docker set up, and docker-compose installed.
 version: '2'
 services:
-  cando:
-    image: cando
-    build:
-      context: .
-      dockerfile: tools/dockerfiles/cando/Dockerfile
-    # depends_on:
-    #   - clasp
-  clasp:
-    image: clasp
-    build:
-      context: .
-      dockerfile: tools/dockerfiles/clasp/Dockerfile
-    depends_on:
-      - clasp-build
+  # first, run: docker-compose run clasp-build
+  # this will compile clasp and copy the Linux/ELF binary to ./build/clasp
   clasp-build:
     image: clasp-build
     build:
@@ -22,3 +12,21 @@ services:
     entrypoint: cp -v build/clasp /build/
     volumes:
       - ./build:/build
+  # second, run: docker-compose build clasp
+  # this will "ADD ./build/clasp"
+  # into a smaller base image with the runtime dependencies
+  clasp:
+    image: clasp
+    build:
+      context: .
+      dockerfile: tools/dockerfiles/clasp/Dockerfile
+    depends_on:
+      - clasp-build
+  # cando is in turn built upon the clasp runtime image
+  cando:
+    image: cando
+    build:
+      context: .
+      dockerfile: tools/dockerfiles/cando/Dockerfile
+    # depends_on:
+    #   - clasp

--- a/tools/dockerfiles/cando/Dockerfile
+++ b/tools/dockerfiles/cando/Dockerfile
@@ -4,20 +4,21 @@ MAINTAINER Christian Schafmeister <meister@temple.edu>
 RUN apt-get update && apt-get -y install python2.7 python-pip python-dev \
   ipython ipython-notebook git-core
 
+# get quicklisp and slime
 RUN git clone https://github.com/quicklisp/quicklisp-client.git /quicklisp
 RUN git clone https://github.com/slime/slime /slime
 RUN clasp -e '(load "/slime/swank-loader.lisp")'\
           -e "(swank-loader:init :delete nil :reload nil :load-contribs nil)"\
           -e "(quit)"
 
-# get the setup-cando file
+# get the setup-cando file from this repo?
 RUN cd ~/clasp && git pull origin testing --rebase
 RUN cd ~/clasp/extensions/cando && git pull origin dev --rebase
 RUN clasp -f "setup-cando"\
           -e '(load "/quicklisp/setup.lisp")'\
           -e "(quit)"
 
-# get subprojects from quicklisp
+# get subprojects for quicklisp
 WORKDIR /quicklisp/local-projects
 RUN git clone https://github.com/clasp-developers/usocket.git
 RUN git clone https://github.com/clasp-developers/cl-jupyter.git

--- a/tools/dockerfiles/cando/Dockerfile
+++ b/tools/dockerfiles/cando/Dockerfile
@@ -1,0 +1,48 @@
+FROM benton/clasp
+MAINTAINER Christian Schafmeister <meister@temple.edu>
+
+RUN apt-get update && apt-get -y install python2.7 python-pip python-dev \
+  ipython ipython-notebook git-core
+
+RUN git clone https://github.com/quicklisp/quicklisp-client.git /quicklisp
+RUN git clone https://github.com/slime/slime /slime
+RUN clasp -e '(load "/slime/swank-loader.lisp")'\
+          -e "(swank-loader:init :delete nil :reload nil :load-contribs nil)"\
+          -e "(quit)"
+
+# get the setup-cando file
+RUN cd ~/clasp && git pull origin testing --rebase
+RUN cd ~/clasp/extensions/cando && git pull origin dev --rebase
+RUN clasp -f "setup-cando"\
+          -e '(load "/quicklisp/setup.lisp")'\
+          -e "(quit)"
+
+# get subprojects from quicklisp
+WORKDIR /quicklisp/local-projects
+RUN git clone https://github.com/clasp-developers/usocket.git
+RUN git clone https://github.com/clasp-developers/cl-jupyter.git
+RUN git clone https://github.com/clasp-developers/bordeaux-threads.git
+RUN git clone https://github.com/clasp-developers/cffi.git
+RUN clasp -f "setup-cando"\
+          -e '(load "/quicklisp/setup.lisp")'\
+          -e "(require :inet)"\
+          -e '(setq core::*swank-home* "/home/app/slime")'\
+          -e '(load (format nil "~a/swank-loader.lisp" core::*swank-home*))'\
+          -e "(swank-loader:init :delete nil :reload nil :load-contribs nil)"\
+          -e "(quit)"
+
+# install Jupyter
+RUN pip install jupyter
+ADD tools/dockerfiles/jupyter/kernel.json \
+  /root/.local/share/jupyter/kernels/lisp/kernel.json
+RUN clasp -e '(load "/quicklisp/setup.lisp")'\
+          -e "(ql:quickload :cl-jupyter)"\
+          -e "(ql:quickload :cffi)"\
+          -e "(ql:quickload :cffi-grovel)"\
+          -e "(ql:quickload :nibbles)"\
+          -e "(ql:quickload :ironclad)"\
+          -e "(ql:quickload :uuid)"\
+          -e "(ql:quickload :trivial-utf-8)"\
+          -e "(quit)"
+
+CMD [ "jupyter", "notebook", "--no-browser", "--ip=0.0.0.0", "--port=8888" ]

--- a/tools/dockerfiles/cando/Dockerfile
+++ b/tools/dockerfiles/cando/Dockerfile
@@ -1,43 +1,50 @@
-FROM benton/clasp
+FROM clasp
 MAINTAINER Christian Schafmeister <meister@temple.edu>
 
-RUN apt-get update && apt-get -y install python2.7 python-pip python-dev \
-  ipython ipython-notebook git-core
+# install Jupyter and its dependencies; configure jupyter kernel
+USER root
+RUN apt-get update && apt-get -y install git-core \
+  python2.7 python-pip python-dev ipython ipython-notebook
+RUN pip install --upgrade pip && pip install jupyter
+ADD tools/dockerfiles/jupyter/kernel.json \
+  /home/app/.local/share/jupyter/kernels/lisp/kernel.json
 
-# get quicklisp and slime
-RUN git clone https://github.com/quicklisp/quicklisp-client.git /quicklisp
-RUN git clone https://github.com/slime/slime /slime
-RUN clasp -e '(load "/slime/swank-loader.lisp")'\
-          -e "(swank-loader:init :delete nil :reload nil :load-contribs nil)"\
+# add cando extension
+ADD extensions/cando/src/lisp $HOME/clasp/extensions/cando/src/lisp
+
+# set ownership and permissions before changing to app user
+RUN chown -R app:app /home/app/.local $HOME/clasp/extensions/cando/src/lisp
+
+# checkout quicklisp and its subprojects
+USER app
+RUN git clone --depth=1 https://github.com/quicklisp/quicklisp-client.git \
+  $HOME/quicklisp
+RUN mkdir $HOME/quicklisp/local-projects
+RUN cd $HOME/quicklisp/local-projects \
+ && git clone --depth=1 https://github.com/clasp-developers/usocket.git \
+ && git clone --depth=1 https://github.com/clasp-developers/cl-jupyter.git \
+ && git clone --depth=1 https://github.com/clasp-developers/bordeaux-threads.git \
+ && git clone --depth=1 https://github.com/clasp-developers/cffi.git
+
+# checkout slime
+RUN git clone --depth=1 https://github.com/slime/slime $HOME/slime
+
+RUN clasp -f "setup-cando"\
+          -e '(load "/home/app/quicklisp/setup.lisp")'\
           -e "(quit)"
 
-# get the setup-cando file from this repo?
-RUN cd ~/clasp && git pull origin testing --rebase
-RUN cd ~/clasp/extensions/cando && git pull origin dev --rebase
 RUN clasp -f "setup-cando"\
-          -e '(load "/quicklisp/setup.lisp")'\
-          -e "(quit)"
-
-# get subprojects for quicklisp
-WORKDIR /quicklisp/local-projects
-RUN git clone https://github.com/clasp-developers/usocket.git
-RUN git clone https://github.com/clasp-developers/cl-jupyter.git
-RUN git clone https://github.com/clasp-developers/bordeaux-threads.git
-RUN git clone https://github.com/clasp-developers/cffi.git
-RUN clasp -f "setup-cando"\
-          -e '(load "/quicklisp/setup.lisp")'\
+          -e '(load "/home/app/quicklisp/setup.lisp")'\
+          -e "(ql:quickload :trivial-http)"\
           -e "(require :inet)"\
           -e '(setq core::*swank-home* "/home/app/slime")'\
           -e '(load (format nil "~a/swank-loader.lisp" core::*swank-home*))'\
           -e "(swank-loader:init :delete nil :reload nil :load-contribs nil)"\
           -e "(quit)"
 
-# install Jupyter
-RUN pip install jupyter
-ADD tools/dockerfiles/jupyter/kernel.json \
-  /root/.local/share/jupyter/kernels/lisp/kernel.json
-RUN clasp -e '(load "/quicklisp/setup.lisp")'\
+RUN clasp -e '(load "/home/app/quicklisp/setup.lisp")'\
           -e "(ql:quickload :cl-jupyter)"\
+          -e "(ql:quickload :pzmq)"\
           -e "(ql:quickload :cffi)"\
           -e "(ql:quickload :cffi-grovel)"\
           -e "(ql:quickload :nibbles)"\
@@ -46,4 +53,5 @@ RUN clasp -e '(load "/quicklisp/setup.lisp")'\
           -e "(ql:quickload :trivial-utf-8)"\
           -e "(quit)"
 
-CMD [ "jupyter", "notebook", "--no-browser", "--ip=0.0.0.0", "--port=8888" ]
+ENTRYPOINT [ "jupyter", "notebook" ]
+CMD        [ "--no-browser", "--ip=0.0.0.0", "--port=8888" ]

--- a/tools/dockerfiles/clasp-build/Dockerfile
+++ b/tools/dockerfiles/clasp-build/Dockerfile
@@ -20,13 +20,12 @@ ENV CC=/usr/bin/clang-4.0 CXX=/usr/bin/clang++-4.0
 # Copy the entire clasp directory less .dockerignore and clean the build dir
 ADD . clasp
 WORKDIR /clasp
-RUN rm -rf build/*
+RUN rm -rf build/* && mkdir -p /out/clasp
 
 # checkout submodules, configure, and build
 RUN echo "LLVM_CONFIG_BINARY='/usr/bin/llvm-config-4.0'" > wscript.config
-RUN echo "INSTALL_PATH_PREFIX='/home/app/clasp/install'" >> wscript.config
+RUN echo "INSTALL_PATH_PREFIX='/out/clasp'" >> wscript.config
 RUN ./waf update_submodules
 RUN ./waf configure
 RUN ./waf -j $(nproc) build_cboehm -v
-
-ENTRYPOINT [ "/clasp/build/clasp" ]
+RUN ./waf install_cboehm

--- a/tools/dockerfiles/clasp-build/Dockerfile
+++ b/tools/dockerfiles/clasp-build/Dockerfile
@@ -24,7 +24,6 @@ RUN echo "LLVM_CONFIG_BINARY='/usr/bin/llvm-config-4.0'" > wscript.config
 RUN echo "INSTALL_PATH_PREFIX='/home/app/clasp/install'" >> wscript.config
 RUN ./waf update_submodules
 RUN CC=/usr/bin/clang-4.0 CXX=/usr/bin/clang++-4.0 ./waf configure
-RUN rm -f build/clasp
 RUN ./waf -j $(nproc) build_cboehm -v
 
 ENTRYPOINT [ "/clasp/build/clasp" ]

--- a/tools/dockerfiles/clasp-build/Dockerfile
+++ b/tools/dockerfiles/clasp-build/Dockerfile
@@ -24,6 +24,7 @@ RUN echo "LLVM_CONFIG_BINARY='/usr/bin/llvm-config-4.0'" > wscript.config
 RUN echo "INSTALL_PATH_PREFIX='/home/app/clasp/install'" >> wscript.config
 RUN ./waf update_submodules
 RUN CC=/usr/bin/clang-4.0 CXX=/usr/bin/clang++-4.0 ./waf configure
+RUN rm -f build/clasp
 RUN ./waf -j $(nproc) build_cboehm -v
 
 ENTRYPOINT [ "/clasp/build/clasp" ]

--- a/tools/dockerfiles/clasp-build/Dockerfile
+++ b/tools/dockerfiles/clasp-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 MAINTAINER Christian Schafmeister <meister@temple.edu>
 
-# install all clasp build deps
+# install all clasp build deps: mostly clang, boost, LLVM4
 RUN apt-get update && apt-get install -y \
   software-properties-common python-software-properties wget
 RUN wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
@@ -15,16 +15,18 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
   clang-4.0 libclang-common-4.0-dev libclang-4.0-dev libclang1-4.0 clang1-4.0-dbg \
   libllvm4.0 libllvm4.0-dbg lldb-4.0 llvm-4.0 llvm-4.0-dev llvm-4.0-doc \
   llvm-4.0-runtime clang-format-4.0 python-clang-4.0 lld-4.0
+ENV CC=/usr/bin/clang-4.0 CXX=/usr/bin/clang++-4.0
 
-# Copy the entire clasp directory less .dockerignore
+# Copy the entire clasp directory less .dockerignore and clean the build dir
 ADD . clasp
 WORKDIR /clasp
+RUN rm -rf build/*
 
+# checkout submodules, configure, and build
 RUN echo "LLVM_CONFIG_BINARY='/usr/bin/llvm-config-4.0'" > wscript.config
 RUN echo "INSTALL_PATH_PREFIX='/home/app/clasp/install'" >> wscript.config
 RUN ./waf update_submodules
-RUN CC=/usr/bin/clang-4.0 CXX=/usr/bin/clang++-4.0 ./waf configure
-RUN rm -f build/clasp
+RUN ./waf configure
 RUN ./waf -j $(nproc) build_cboehm -v
 
 ENTRYPOINT [ "/clasp/build/clasp" ]

--- a/tools/dockerfiles/clasp-build/Dockerfile
+++ b/tools/dockerfiles/clasp-build/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:latest
+MAINTAINER Christian Schafmeister <meister@temple.edu>
+
+# install all clasp build deps
+RUN apt-get update && apt-get install -y \
+  software-properties-common python-software-properties wget
+RUN wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
+RUN apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main"
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+  gcc g++ llvm clang cmake libgc-dev libgmp-dev binutils-gold binutils-dev \
+  zlib1g-dev libncurses-dev libboost-filesystem-dev libboost-regex-dev \
+  libboost-date-time-dev libboost-program-options-dev libboost-system-dev \
+  libboost-iostreams-dev csh flex gfortran zlib1g-dev libbz2-dev patch \
+  git sbcl libexpat-dev wget vim libzmq-dev \
+  clang-4.0 libclang-common-4.0-dev libclang-4.0-dev libclang1-4.0 clang1-4.0-dbg \
+  libllvm4.0 libllvm4.0-dbg lldb-4.0 llvm-4.0 llvm-4.0-dev llvm-4.0-doc \
+  llvm-4.0-runtime clang-format-4.0 python-clang-4.0 lld-4.0
+
+# Copy the entire clasp directory less .dockerignore
+ADD . clasp
+WORKDIR /clasp
+
+RUN echo "LLVM_CONFIG_BINARY='/usr/bin/llvm-config-4.0'" > wscript.config
+RUN echo "INSTALL_PATH_PREFIX='/home/app/clasp/install'" >> wscript.config
+RUN ./waf update_submodules
+RUN CC=/usr/bin/clang-4.0 CXX=/usr/bin/clang++-4.0 ./waf configure
+RUN rm -f build/clasp
+RUN ./waf -j $(nproc) build_cboehm -v
+
+ENTRYPOINT [ "/clasp/build/clasp" ]

--- a/tools/dockerfiles/clasp-build/Dockerfile
+++ b/tools/dockerfiles/clasp-build/Dockerfile
@@ -29,3 +29,7 @@ RUN ./waf update_submodules
 RUN ./waf configure
 RUN ./waf -j $(nproc) build_cboehm -v
 RUN ./waf install_cboehm
+
+# add app user, to set correct UID and GID on files
+RUN groupadd -g 9999 app && useradd -u 9999 -g 9999 -ms /bin/bash app
+RUN chown -R app:app /out/clasp

--- a/tools/dockerfiles/clasp/Dockerfile
+++ b/tools/dockerfiles/clasp/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update && apt-get -y install \
   libboost-iostreams1.58.0 libgc1c2 llvm-4.0-runtime libgmpxx4ldbl
 
 # add clasp binaries
-ADD ./clasp /usr/local/bin/clasp
+ADD ./build/clasp /usr/local/bin/clasp
 RUN chmod 0755 /usr/local/bin/clasp
 
-ENTRYPOINT [ "/usr/local/bin/clasp" ]
+ENTRYPOINT [ "clasp" ]

--- a/tools/dockerfiles/clasp/Dockerfile
+++ b/tools/dockerfiles/clasp/Dockerfile
@@ -18,7 +18,6 @@ ENV HOME=/home/app
 
 # add clasp build output
 ADD ./build/clasp.tgz ${HOME}/clasp
-RUN chown -R app:app ${HOME}/clasp
 
 USER app
 WORKDIR $HOME

--- a/tools/dockerfiles/clasp/Dockerfile
+++ b/tools/dockerfiles/clasp/Dockerfile
@@ -23,4 +23,5 @@ RUN chown app:app ${HOME}/clasp
 
 USER app
 WORKDIR $HOME
+ENV PATH "$PATH:$HOME/clasp/bin"
 ENTRYPOINT [ "/home/app/clasp/bin/clasp" ]

--- a/tools/dockerfiles/clasp/Dockerfile
+++ b/tools/dockerfiles/clasp/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 MAINTAINER Christian Schafmeister <meister@temple.edu>
 
 # add LLVM repo
-RUN apt-get -y update && apt-get -y install wget
+RUN apt-get -y update && apt-get -y install wget && apt-get clean
 RUN wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
 RUN echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main'\
   >/etc/apt/sources.list.d/llvm4.list
@@ -10,7 +10,8 @@ RUN echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main'\
 # install clasp runtime dependencies
 RUN apt-get -y update && apt-get -y install \
   libboost-filesystem1.58.0 libboost-date-time1.58.0 libboost-program-options1.58.0 \
-  libboost-iostreams1.58.0 libgc1c2 llvm-4.0-runtime libgmpxx4ldbl
+  libboost-iostreams1.58.0 libgc1c2 llvm-4.0-runtime libgmpxx4ldbl \
+  && apt-get clean
 
 # add app user
 RUN groupadd -g 9999 app && useradd -u 9999 -g 9999 -ms /bin/bash app
@@ -18,6 +19,7 @@ ENV HOME=/home/app
 
 # add clasp build output
 ADD ./build/clasp.tgz ${HOME}/clasp
+RUN chown app:app ${HOME}/clasp
 
 USER app
 WORKDIR $HOME

--- a/tools/dockerfiles/clasp/Dockerfile
+++ b/tools/dockerfiles/clasp/Dockerfile
@@ -24,4 +24,4 @@ RUN chown app:app ${HOME}/clasp
 USER app
 WORKDIR $HOME
 ENV PATH "$PATH:$HOME/clasp/bin"
-ENTRYPOINT [ "/home/app/clasp/bin/clasp" ]
+ENTRYPOINT [ "clasp" ]

--- a/tools/dockerfiles/clasp/Dockerfile
+++ b/tools/dockerfiles/clasp/Dockerfile
@@ -1,11 +1,13 @@
 FROM ubuntu:latest
 MAINTAINER Christian Schafmeister <meister@temple.edu>
 
+# add LLVM repo
 RUN apt-get -y update && apt-get -y install wget
 RUN wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
 RUN echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main'\
   >/etc/apt/sources.list.d/llvm4.list
 
+# install clasp runtime dependencies
 RUN apt-get -y update && apt-get -y install \
   libboost-filesystem1.58.0 libboost-date-time1.58.0 libboost-program-options1.58.0 \
   libboost-iostreams1.58.0 libgc1c2 llvm-4.0-runtime libgmpxx4ldbl

--- a/tools/dockerfiles/clasp/Dockerfile
+++ b/tools/dockerfiles/clasp/Dockerfile
@@ -12,8 +12,14 @@ RUN apt-get -y update && apt-get -y install \
   libboost-filesystem1.58.0 libboost-date-time1.58.0 libboost-program-options1.58.0 \
   libboost-iostreams1.58.0 libgc1c2 llvm-4.0-runtime libgmpxx4ldbl
 
-# add clasp binaries
-ADD ./build/clasp /usr/local/bin/clasp
-RUN chmod 0755 /usr/local/bin/clasp
+# add app user
+RUN groupadd -g 9999 app && useradd -u 9999 -g 9999 -ms /bin/bash app
+ENV HOME=/home/app
 
-ENTRYPOINT [ "clasp" ]
+# add clasp build output
+ADD ./build/clasp.tgz ${HOME}/clasp
+RUN chown -R app:app ${HOME}/clasp
+
+USER app
+WORKDIR $HOME
+ENTRYPOINT [ "/home/app/clasp/bin/clasp" ]

--- a/tools/dockerfiles/clasp/Dockerfile
+++ b/tools/dockerfiles/clasp/Dockerfile
@@ -1,17 +1,17 @@
 FROM ubuntu:latest
 MAINTAINER Christian Schafmeister <meister@temple.edu>
 
-# install all clasp runtime deps
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-  libgc libgmp binutils-gold binutils \
-  zlib1g libncurses libboost-filesystem libboost-regex \
-  libboost-date-time libboost-program-options libboost-system \
-  libboost-iostreams csh flex gfortran zlib1g libbz2 patch \
-  git sbcl libexpat
+RUN apt-get -y update && apt-get -y install wget
+RUN wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
+RUN echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main'\
+  >/etc/apt/sources.list.d/llvm4.list
+
+RUN apt-get -y update && apt-get -y install \
+  libboost-filesystem1.58.0 libboost-date-time1.58.0 libboost-program-options1.58.0 \
+  libboost-iostreams1.58.0 libgc1c2 llvm-4.0-runtime libgmpxx4ldbl
 
 # add clasp binaries
-ADD build /clasp/build
+ADD ./clasp /usr/local/bin/clasp
+RUN chmod 0755 /usr/local/bin/clasp
 
-# install into $PATH
-
-ENTRYPOINT ['clasp']
+ENTRYPOINT [ "/usr/local/bin/clasp" ]


### PR DESCRIPTION
This version uses a feature of Dockerfile's `ADD` directive that automatically unpacks archive files. The build output from clasp is packaged up into a single `./build/clasp.tgz` file, instead of a full directory of files. This more reliably preserves user and group IDs across the build and runtime images, and avoids "littering" the user's workstation unnecessarily.

Running `chown -R app:app $HOME/clasp` within a docker build turns out to generate a new filesystem layer with a full copy of every original file, effectively doubling the size of the layer's contents even though only ownership is modified. To avoid this problem, the `app` user and `chown` statement have been (re-)added to the build image. The `clasp.tgz` file generated by `docker-compose run clasp-build` preserves the ownership of the files when they are `ADD`ed to the runtime image.

The final runtime image for `clasp` is about 1.1GB. When based on the 130MB ubuntu base, this is about as small as it can get, given that the build output itself is over 800MB, with LLVM adding another 40MB.


